### PR TITLE
Add 'NoDesktopIcon' package paramater

### DIFF
--- a/microsoft-edge/README.md
+++ b/microsoft-edge/README.md
@@ -1,3 +1,7 @@
 microsoft-edge (stable channel)
 
 This package is the stable version of the Microsoft Edge browser, based on the Chromium open source browser. Portions of this browser are based on Third Party Open source software. The entire list of Microsoft utilized open source is available at https://thirdpartysource.microsoft.com/ while the portions and licenses specific to Edge are available at edge://credits/ once installed.
+
+## Package parameters
+* `/NoDesktopIcon` - Don't add a desktop icon.
+Example: `choco install microsoft-edge --params "/NoDesktopIcon"`

--- a/microsoft-edge/microsoft-edge.nuspec
+++ b/microsoft-edge/microsoft-edge.nuspec
@@ -17,6 +17,9 @@
     <tags>edge microsoft browser stable chromium</tags>
     <summary>Microsoft Edge browser, based on the Chromium open source browser.</summary>
     <description><![CDATA[This package is the stable version of the Microsoft Edge browser, based on the Chromium open source browser. Portions of this browser are based on Third Party Open source software. The entire list of Microsoft utilized open source is available at https://thirdpartysource.microsoft.com/ while the portions and licenses specific to Edge are available at edge://credits/ once installed.
+## Package parameters
+* `/NoDesktopIcon` - Don't add a desktop icon.
+Example: `choco install microsoft-edge --params "/NoDesktopIcon"`
 ]]></description>
       <releaseNotes>https://www.microsoftedgeinsider.com/en-us/whats-new</releaseNotes>
   </metadata>

--- a/microsoft-edge/tools/chocolateyinstall.ps1
+++ b/microsoft-edge/tools/chocolateyinstall.ps1
@@ -3,6 +3,11 @@ $ErrorActionPreference = 'Stop';
 $url32 = 'https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/d491c8d8-730d-47ed-bf64-58144fca727b/MicrosoftEdgeEnterpriseX86.msi'
 $url64 = 'https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/d1ec9411-fa61-4946-a93d-b0db1ae42cf4/MicrosoftEdgeEnterpriseX64.msi'
 
+$toolsDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+. $toolsDir\helpers.ps1
+
+$pp = Get-PackageParameters
+
 $packageArgs = @{
   packageName    = $env:ChocolateyPackageName
   fileType       = 'MSI'
@@ -16,7 +21,7 @@ $packageArgs = @{
   checksum64     = '9FB32426503C31B5D59BF3365CAE8003B46487E9B411FAB8DB5C115270A9A4FD'
   checksumType64 = 'sha256'
 
-  silentArgs     = "/qn /norestart /l*v `"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`""
+  silentArgs     = "{0} /qn /norestart /l*v `"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`"" -f (CheckNoDestop $pp)
   validExitCodes = @(0, 3010, 1641)
 }
 

--- a/microsoft-edge/tools/helpers.ps1
+++ b/microsoft-edge/tools/helpers.ps1
@@ -1,6 +1,6 @@
 function CheckNoDestop([hashtable] $pp) {
 	if ($pp['NoDesktopIcon']) {
-		Write-Host "Disabling Desktop as requested"
+		Write-Host "Disabling Desktop icon as requested"
 		return 'DONOTCREATEDESKTOPSHORTCUT=true'
 	}
 }

--- a/microsoft-edge/tools/helpers.ps1
+++ b/microsoft-edge/tools/helpers.ps1
@@ -1,0 +1,6 @@
+function CheckNoDestop([hashtable] $pp) {
+	if ($pp['NoDesktopIcon']) {
+		Write-Host "Disabling Desktop as requested"
+		return 'DONOTCREATEDESKTOPSHORTCUT=true'
+	}
+}


### PR DESCRIPTION
Allows for installation without the desktop icon shortcut

Now, if '/NoDesktopIcon' is added as a package parameter, it enables the 'DONOTCREATEDESKTOPSHORTCUT=true' parameter checked by the edge msi installer.