### PR TITLE
check for existing install version

### DIFF
--- a/microsoft-edge/tools/chocolateyinstall.ps1
+++ b/microsoft-edge/tools/chocolateyinstall.ps1
@@ -20,4 +20,21 @@ $packageArgs = @{
   validExitCodes = @(0, 3010, 1641)
 }
 
-Install-ChocolateyPackage @packageArgs
+$32Path = Join-Path -Path ${Env:ProgramFiles(x86)} -ChildPath 'Microsoft\Edge\Application\msedge.exe'
+$64Path = Join-Path -Path $Env:ProgramFiles -ChildPath 'Microsoft\Edge\Application\msedge.exe'
+
+if (Test-Path $32Path)
+{
+  [Version]$InstalledVersion = (Get-ItemProperty -Path $32Path).VersionInfo.ProductVersion
+}
+if (Test-Path $64Path)
+{
+  [Version]$InstalledVersion = (Get-ItemProperty -Path $64Path).VersionInfo.ProductVersion
+}
+
+$UpdateNeeded = $InstalledVersion -lt [Version]$Env:ChocolateyPackageVersion
+
+if ($UpdateNeeded -or $Env:ChocolateyForce)
+{
+  Install-ChocolateyPackage @packageArgs
+}


### PR DESCRIPTION
Basically, if there is an existing version, and it is already up-to-date with the package version - just mark the package a success and skip the install attempt.

If the package is run against a machine that already has this or a later version of the browser installed, the install will fail. Instead of allowing the package the fail, check to see if the browser is already up-to-date.  There are several mechanisms that may update the browser faster than the chocolatey package version will allow -- third party software updates, rapid releases directly from the vendor, a built-in auto-updater, etc.

This will allow new or existing chocolatey users to transition to this package without causing errors, and will also prevent errors if the browser was already updated.