### PR TITLE
Ente Auth upgrade to v4.4.23

### DIFF
--- a/ente-auth/ente-auth.nuspec
+++ b/ente-auth/ente-auth.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ente-auth</id>
-    <version>4.4.22</version>
+    <version>4.4.23</version>
     <owners>Dennis Gaida</owners>
     <title>Ente Auth</title>
     <authors>ente Technologies</authors>

--- a/ente-auth/tools/chocolateyinstall.ps1
+++ b/ente-auth/tools/chocolateyinstall.ps1
@@ -1,6 +1,6 @@
 ﻿
 $ErrorActionPreference = 'Stop';
-$url32 = 'https://github.com/ente-io/ente/releases/download/auth-v4.4.22/ente-auth-v4.4.22-installer.exe'
+$url32 = 'https://github.com/ente/ente/releases/download/auth-v4.4.23/ente-auth-v4.4.23-installer.exe'
 
 $packageArgs = @{
   packageName    = $env:ChocolateyPackageName
@@ -9,7 +9,7 @@ $packageArgs = @{
 
   softwareName   = 'Ente Auth'
 
-  checksum       = 'd2e6e8919cbca42529fd2f0a220eb30691313375b689a34889f79f3409eccb1c'
+  checksum       = '358b7ed81c457437babed7ac93a2787ba3e50941bf8069bacb4caf148d92d254'
   checksumType   = 'sha256'
 
   silentArgs     = "{0} /VERYSILENT /SUPPRESSMSGBOXES /LOG=`"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).installer.log`""


### PR DESCRIPTION
Hey Dennis,

Ente Auth was upgrade to 4.4.23 on June 9 and here are the changes needed for your chocolatey package!
Please note: between the last two versions the project renamed its Github root from "ente-io" to "ente".

Best regards,
Alexander