### PR TITLE
Update Ente Auth to v4.4.24

### DIFF
--- a/ente-auth/ente-auth.nuspec
+++ b/ente-auth/ente-auth.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>ente-auth</id>
-    <version>4.4.17</version>
+    <version>4.4.24</version>
     <owners>Dennis Gaida</owners>
     <title>Ente Auth</title>
     <authors>ente Technologies</authors>

--- a/ente-auth/tools/chocolateyinstall.ps1
+++ b/ente-auth/tools/chocolateyinstall.ps1
@@ -1,6 +1,6 @@
 ﻿
 $ErrorActionPreference = 'Stop';
-$url32 = 'https://github.com/ente/ente/releases/download/auth-v4.4.23/ente-auth-v4.4.23-installer.exe'
+$url32 = 'https://github.com/ente/ente/releases/download/auth-v4.4.24/ente-auth-v4.4.24-installer.exe'
 
 $packageArgs = @{
   packageName    = $env:ChocolateyPackageName
@@ -9,7 +9,7 @@ $packageArgs = @{
 
   softwareName   = 'Ente Auth'
 
-  checksum       = '358b7ed81c457437babed7ac93a2787ba3e50941bf8069bacb4caf148d92d254'
+  checksum       = '85b237940c8f0f517786494089ad2849d845671322188302738513dbd80e42b8'
   checksumType   = 'sha256'
 
   silentArgs     = "{0} /VERYSILENT /SUPPRESSMSGBOXES /LOG=`"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).installer.log`""

--- a/ente-auth/update.ps1
+++ b/ente-auth/update.ps1
@@ -31,11 +31,14 @@ function global:au_GetLatest {
   # get download URL
   $download_url = $current_release.assets | Where-Object -Property name -like "*installer.exe" | Select-Object -Expand browser_download_url
 
-  # prefer sha256sum-windows, fall back to sha256sum
+  # prefer sha256sum-windows, fall back to sha256sum or SHA256SUMS afterwards
   $checksum_url = $current_release.assets | Where-Object -Property name -eq "sha256sum-windows" | Select-Object -Expand browser_download_url
   if (-not $checksum_url) {
     $checksum_url = $current_release.assets | Where-Object -Property name -eq "sha256sum" | Select-Object -Expand browser_download_url
   }
+  if (-not $checksum_url) {
+    $checksum_url = $current_release.assets | Where-Object -Property name -eq "SHA256SUMS" | Select-Object -Expand browser_download_url
+  } 
 
   $tmpChecksumFile = "$($env:TEMP)\$ente_auth_tag_prefix-sha256"
   Invoke-WebRequest $checksum_url -OutFile $tmpChecksumFile

--- a/microsoft-edge/microsoft-edge.nuspec
+++ b/microsoft-edge/microsoft-edge.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>microsoft-edge</id>
-    <version>146.0.3856.109</version>
+    <version>149.0.4022.96</version>
     <owners>Dennis Gaida</owners>
     <title>Microsoft Edge</title>
     <authors>Microsoft</authors>

--- a/microsoft-edge/tools/chocolateyinstall.ps1
+++ b/microsoft-edge/tools/chocolateyinstall.ps1
@@ -1,7 +1,7 @@
 ﻿
 $ErrorActionPreference = 'Stop';
-$url32 = 'https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/9e400cb8-75c9-4f78-8c6e-7e0dbd927eed/MicrosoftEdgeEnterpriseX86.msi'
-$url64 = 'https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/a4db920c-174d-4cb2-8190-c1abd54c49ee/MicrosoftEdgeEnterpriseX64.msi'
+$url32 = 'https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/2e339ca2-9d6d-4738-8cde-a522e174c630/MicrosoftEdgeEnterpriseX86.msi'
+$url64 = 'https://msedge.sf.dl.delivery.mp.microsoft.com/filestreamingservice/files/96f71ebf-d93a-4a10-80af-5c5380af81f5/MicrosoftEdgeEnterpriseX64.msi'
 
 $toolsDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
 . $toolsDir\helpers.ps1
@@ -16,9 +16,9 @@ $packageArgs = @{
 
   softwareName   = 'Microsoft Edge'
 
-  checksum       = '7C8E6C03D1667A8B3A6FB54E9D8A16B58449671B5403B3B655C39CDB226B5EDE'
+  checksum       = '057F2C50576DE572AD575013FC83B2CC72B20DD65BAF2E792B3E5997B2AF2847'
   checksumType   = 'sha256'
-  checksum64     = 'F78FEB2FB3A1D7F7249A467558D7EA29C98EB70D6D8CE4DA061C459C147F6BFE'
+  checksum64     = '793F753122566FE30E1382B148725A4FEDFEEB79732608E2FBA78B498166AEB3'
   checksumType64 = 'sha256'
 
   silentArgs     = "{0} /qn /norestart /l*v `"$($env:TEMP)\$($packageName).$($env:chocolateyPackageVersion).MsiInstall.log`"" -f (CheckNoDestop $pp)


### PR DESCRIPTION
Hey it's me again 😄 

Obviously the Ente guys have yet again introduced another checksum file, now called SHA256SUMS. So your automation doesn't work, again.

First I added this new filename variant to the update.ps1 file.

Second I manually updated the other two files with version number, download URL and checksum.

As soon as I created the branch from my up-to-date main branch I also got the committed change in the microsoft-edge package. Couldn't do anything about it, even with another new branch. I guess it happens automatically in background.

Feel free to remove these changes from the PR, of course!

Best regards,
Alexamder